### PR TITLE
Release version 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "utf8-command"
-version = "1.0.0"
+version = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utf8-command"
-version = "1.0.0"
+version = "1.0.1"
 description = "UTF-8 encoded `std::process::Command` output"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Update version to 1.0.1 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.